### PR TITLE
Fix MessageBox on exit confirmation

### DIFF
--- a/TransparentTwitchChatWPF/MainWindow.xaml.cs
+++ b/TransparentTwitchChatWPF/MainWindow.xaml.cs
@@ -374,7 +374,12 @@ namespace TransparentTwitchChatWPF
         {
             if (this.genSettings.ConfirmClose)
             {
-                if (MessageBox.Show("Sure you want to exit the application?", "Exit", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                var msgBoxResult = MessageBox.Show("Sure you want to exit the application?", "Exit", 
+                                                    MessageBoxButton.YesNo, 
+                                                    MessageBoxImage.Question,
+                                                    MessageBoxResult.No,
+                                                    MessageBoxOptions.DefaultDesktopOnly);
+                if (msgBoxResult == MessageBoxResult.Yes)
                 {
                     System.Windows.Application.Current.Shutdown();
                 }


### PR DESCRIPTION
Hi,

On **Windows 10 2004** (I didn't test it on earlier versions), I can't shut down application properly, because MessageBox doesn't appear... or It's appeared, but only for microseconds. It happens, because application doesn't have visible window on foreground, so User can't interreact with MessageBox correctly and return enum **MessageBoxResult.No**. I fixed this problem by add only two additional parameters to your MessageBox.Show(...):

- **MessageBoxResult.No** -> because It's natural way to create exit confirmation message box,
- **MessageBoxOptions.DefaultDesktopOnly** -> MessageBox should appear even application doesn't have visible window on foreground.