### PR TITLE
Persist cookies

### DIFF
--- a/TransparentTwitchChatWPF/MainWindow.xaml.cs
+++ b/TransparentTwitchChatWPF/MainWindow.xaml.cs
@@ -127,6 +127,15 @@ namespace TransparentTwitchChatWPF
 
         public MainWindow()
         {
+            CefSettings settings = new CefSettings()
+            {
+                PersistSessionCookies = true,
+                PersistUserPreferences = true,
+                RootCachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TransparentTwitchChatWPF", "cef"),
+                CachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TransparentTwitchChatWPF", "cef", "cache")
+            };
+            Cef.Initialize(settings);
+
             InitializeComponent();
             DataContext = this;
 
@@ -136,10 +145,18 @@ namespace TransparentTwitchChatWPF
 
             var browserSettings = new BrowserSettings
             {
+                ApplicationCache = CefState.Enabled,
+                LocalStorage = CefState.Enabled,
                 FileAccessFromFileUrls = CefState.Enabled,
-                UniversalAccessFromFileUrls = CefState.Enabled
+                UniversalAccessFromFileUrls = CefState.Enabled,
             };
             Browser1.BrowserSettings = browserSettings;
+            Browser1.RequestContext = new RequestContext(new RequestContextSettings()
+            {
+                CachePath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TransparentTwitchChatWPF", "cef", "cache"),
+                PersistSessionCookies = true,
+                PersistUserPreferences = true,
+            });
             CefSharpSettings.LegacyJavascriptBindingEnabled = true;
 
             //this.Browser1.RegisterAsyncJsObject("jsCallback", new JsCallbackFunctions());


### PR DESCRIPTION
This PR allows the browser to save the user's cookies and localStorage in a folder next to the settings:
![image](https://user-images.githubusercontent.com/24357633/133759867-56d1b0aa-d6fd-4f9d-8fa2-8a6867f30087.png)

This makes the Twitch popout chat way friendlier to use, since you don't have to log in every time you start the application anymore.

As you can see here, I'm starting the application already logged in from my previous session:
![gif2](https://user-images.githubusercontent.com/24357633/133760607-ff8cd478-8c41-4ed1-bb1b-8e9a4fa9a3f9.gif)
