### PR TITLE
Add BetterTTV and FrankerFaceZ to Twitch popout

### DIFF
--- a/TransparentTwitchChatWPF/MainWindow.xaml.cs
+++ b/TransparentTwitchChatWPF/MainWindow.xaml.cs
@@ -583,6 +583,41 @@ if (vips.includes(nick.toLowerCase()))
     return oldChatInsert.apply(oldChatInsert, arguments);
 }
 }";*/
+                if (SettingsSingleton.Instance.genSettings.ChatType == (int)ChatTypes.TwitchPopout)
+                {
+                    if (SettingsSingleton.Instance.genSettings.BetterTtv)
+                    {
+                        InsertCustomJavaScriptFromUrl("https://cdn.betterttv.net/betterttv.js");
+                    }
+                    if (SettingsSingleton.Instance.genSettings.FrankerFaceZ)
+                    {
+                        // Observe for FrankerFaceZ's reskin stylesheet
+                        // that breaks the transparency and remove it
+                        InsertCustomJavaScript(@"
+(function() {
+    const head = document.getElementsByTagName(""head"")[0];
+    const observer = new MutationObserver((mutations, observer) => {
+        for (const mut of mutations) {
+            if (mut.type === ""childList"") {
+                for (const node of mut.addedNodes) {
+                    if (node.tagName.toLowerCase() === ""link"" && node.href.includes(""color_normalizer"")) {
+                        node.remove();
+                    }
+                }
+            }
+        }
+    });
+    observer.observe(head, {
+        attributes: false,
+        childList: true,
+        subtree: false,
+    });
+})();
+                        ");
+
+                        InsertCustomJavaScriptFromUrl("https://cdn.frankerfacez.com/static/script.min.js");
+                    }
+                }
             }
         }
 
@@ -620,6 +655,17 @@ if (vips.includes(nick.toLowerCase()))
             {
                 MessageBox.Show(e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
+        }
+
+        private void InsertCustomJavaScriptFromUrl(string scriptUrl)
+        {
+            InsertCustomJavaScript(@"
+(function() {
+    const script = document.createElement(""script"");
+    script.src = """ + scriptUrl + @""";
+    document.getElementsByTagName(""head"")[0].appendChild(script);
+})();
+            ");
         }
 
         public void CreateNewWindow(string URL)
@@ -669,7 +715,9 @@ if (vips.includes(nick.toLowerCase()))
                 HideTaskbarIcon = SettingsSingleton.Instance.genSettings.HideTaskbarIcon,
                 AllowInteraction = SettingsSingleton.Instance.genSettings.AllowInteraction,
                 RedemptionsEnabled = SettingsSingleton.Instance.genSettings.RedemptionsEnabled,
-                ChannelID = SettingsSingleton.Instance.genSettings.ChannelID
+                ChannelID = SettingsSingleton.Instance.genSettings.ChannelID,
+                BetterTtv = SettingsSingleton.Instance.genSettings.BetterTtv,
+                FrankerFaceZ = SettingsSingleton.Instance.genSettings.FrankerFaceZ,
             };
 
             SettingsWindow settingsWindow = new SettingsWindow(this, config);
@@ -693,6 +741,9 @@ if (vips.includes(nick.toLowerCase()))
 
                     if (!string.IsNullOrEmpty(SettingsSingleton.Instance.genSettings.Username))
                         SetCustomChatAddress("https://www.twitch.tv/popout/" + SettingsSingleton.Instance.genSettings.Username + "/chat?popout=");
+
+                    SettingsSingleton.Instance.genSettings.BetterTtv = config.BetterTtv;
+                    SettingsSingleton.Instance.genSettings.FrankerFaceZ = config.FrankerFaceZ;
                 }
                 else if (config.ChatType == (int)ChatTypes.KapChat)
                 {
@@ -1099,5 +1150,9 @@ if (vips.includes(nick.toLowerCase()))
         public string ChannelID { get; set; }
         [Trackable]
         public string OAuthToken { get; set; }
+        [Trackable]
+        public bool BetterTtv { get; set; }
+        [Trackable]
+        public bool FrankerFaceZ { get; set; }
     }
 }

--- a/TransparentTwitchChatWPF/SettingsSingleton.cs
+++ b/TransparentTwitchChatWPF/SettingsSingleton.cs
@@ -42,7 +42,9 @@ namespace TransparentTwitchChatWPF
                 FilterAllowAllVIPs = false,
                 AllowedUsersList = new StringCollection(),
                 RedemptionsEnabled = false,
-                ChannelID = string.Empty
+                ChannelID = string.Empty,
+                BetterTtv = false,
+                FrankerFaceZ = false,
             };
         }
     }

--- a/TransparentTwitchChatWPF/SettingsWindow.xaml
+++ b/TransparentTwitchChatWPF/SettingsWindow.xaml
@@ -49,12 +49,15 @@
             <Grid Name ="twitchPopoutChat" Visibility="Hidden" Grid.Column="1">
                 <Label Content="Username" HorizontalAlignment="Left" Margin="12,22,0,0" VerticalAlignment="Top" FontWeight="Bold"/>
                 <TextBox Name="tbTwitchPopoutUsername" HorizontalAlignment="Left" Height="23" Width="240" Margin="20,52,0,0" TextWrapping="NoWrap" Text="username" VerticalAlignment="Top" />
-                <Label Content="Custom CSS" HorizontalAlignment="Left" Margin="12,75,0,0" FontWeight="Bold" />
+                <Label Content="Extensions" HorizontalAlignment="Left" Margin="12,75,0,0" VerticalAlignment="Top" FontWeight="Bold"/>
+                <CheckBox Name="cbBetterTtv" Content="Enable BetterTTV" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="20,100,0,0" />
+                <CheckBox Name="cbFfz" Content="Enable FrankerFaceZ" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="20,120,0,0" />
+                <Label Content="Custom CSS" HorizontalAlignment="Left" Margin="12,140,0,0" FontWeight="Bold" />
                 <TextBox Name="tbPopoutCSS" 
                          HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                          Width="Auto" Height="Auto"
                          HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible" 
-                         Margin="22,100,15,50" TextWrapping="Wrap" AcceptsReturn="true"
+                         Margin="22,170,15,50" TextWrapping="Wrap" AcceptsReturn="true"
                          Text="" />
             </Grid>
             <Grid Name="customURLGrid" Visibility="Hidden" Grid.Column="1">

--- a/TransparentTwitchChatWPF/SettingsWindow.xaml.cs
+++ b/TransparentTwitchChatWPF/SettingsWindow.xaml.cs
@@ -66,7 +66,12 @@ namespace TransparentTwitchChatWPF
                     this.config.TwitchPopoutCSS = this.tbPopoutCSS.Text;
                 }
                 else
+                {
                     this.config.TwitchPopoutCSS = CustomCSS_Defaults.TwitchPopoutChat;
+                }
+
+                this.config.BetterTtv = this.cbBetterTtv.IsChecked ?? false;
+                this.config.FrankerFaceZ = this.cbFfz.IsChecked ?? false;
             }
             else if (this.config.ChatType == (int)ChatTypes.KapChat)
             {
@@ -149,6 +154,9 @@ namespace TransparentTwitchChatWPF
                     this.tbPopoutCSS.Text = CustomCSS_Defaults.TwitchPopoutChat;
                 else
                     this.tbPopoutCSS.Text = this.config.TwitchPopoutCSS;
+
+                this.cbBetterTtv.IsChecked = this.config.BetterTtv;
+                this.cbFfz.IsChecked = this.config.FrankerFaceZ;
             }
             else if (this.config.ChatType == (int)ChatTypes.KapChat)
             {

--- a/TransparentTwitchChatWPF/WindowSettings.cs
+++ b/TransparentTwitchChatWPF/WindowSettings.cs
@@ -33,6 +33,8 @@ namespace TransparentTwitchChatWPF
         public bool AllowInteraction { get; set; }
         public bool RedemptionsEnabled { get; set; }
         public string ChannelID { get; set; }
+        public bool BetterTtv { get; set; }
+        public bool FrankerFaceZ { get; set; }
     }
 
     public static class CustomCSS_Defaults


### PR DESCRIPTION
This PR allows the user to add BTTV's and FFZ's scripts to the Twitch popout browser window.
The feature is available by ticking these boxes in the Twitch Popout settings:
![image](https://user-images.githubusercontent.com/24357633/133761724-1ff78afc-d5a3-498c-aadd-21944245cb66.png)

![gif](https://user-images.githubusercontent.com/24357633/133761520-d3507453-ae6d-4109-bdb9-d03a2eba9b3b.gif)
