### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Some commonly requested features can usually be added with widgets. Please check
 
 ## Star History
 
-<a href="https://star-history.com/#baffler/Transparent-Twitch-Chat-Overlay&Date">
+<a href="https://star-history.dera.page/#baffler/Transparent-Twitch-Chat-Overlay&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=baffler/Transparent-Twitch-Chat-Overlay&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=baffler/Transparent-Twitch-Chat-Overlay&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=baffler/Transparent-Twitch-Chat-Overlay&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=baffler/Transparent-Twitch-Chat-Overlay&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=baffler/Transparent-Twitch-Chat-Overlay&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=baffler/Transparent-Twitch-Chat-Overlay&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken and needs fixing. GitHub's stargazer API restrictions have made the current chart stop rendering, so this updates the Star History section to use a working alternative. The chart image and its wrapping link now point to the replacement domain and display correctly again.